### PR TITLE
show Telegram group ads in snackbar instead

### DIFF
--- a/desktop-ui.json
+++ b/desktop-ui.json
@@ -81,6 +81,24 @@
 			"message": "Lantern is hiring an engineer in India! For more info, and to apply",
 			"thanks": "Thanks for your application!",
 			"button": "Click Here"
+		},
+		"IR": {
+			"enabled":true,
+			"probability": 1.00,
+			"campaign": "20200401",
+			"url": "https://t.me/Lanternpro_Iran",
+			"message": "سلام! اطلاعات بیشتر در مورد لنترن پرو در",
+			"thanks": "",
+			"button": "مشاهده وبسایت"
+		},
+		"fa-IR": {
+			"enabled":true,
+			"probability": 1.00,
+			"campaign": "20200401",
+			"url": "https://t.me/Lanternpro_Iran",
+			"message": "سلام! اطلاعات بیشتر در مورد لنترن پرو در",
+			"thanks": "",
+			"button": "مشاهده وبسایت"
 		}
 	},
   "bannerAds":{
@@ -161,18 +179,6 @@
       "text":"Lantern has partnered with Yinbi to give free YNB to everyone that purchases Lantern Pro! ",
       "link_text":"Get Pro now",
       "url":"#/plans"
-    },
-    "IR":{
-      "enabled":true,
-      "text":"سلام! اطلاعات بیشتر در مورد لنترن پرو در",
-      "link_text":"مشاهده وبسایت",
-      "url":"https://t.me/Lanternpro_Iran"
-    },
-    "fa-IR":{
-      "enabled":true,
-      "text":"سلام! اطلاعات بیشتر در مورد لنترن پرو در",
-      "link_text":"مشاهده وبسایت",
-      "url":"https://t.me/Lanternpro_Iran"
     }
   },
   "homescreenAds": {

--- a/messages.json
+++ b/messages.json
@@ -60,16 +60,6 @@
          "enabled":false,
          "text":"Lantern has partnered with Yinbi to give free YNB to everyone that purchases Lantern Pro! ",
          "url":"https://yin.bi"
-      },
-      "fa_IR":{
-         "enabled":true,
-         "text":"سلام! اطلاعات بیشتر در مورد لنترن پرو در",
-         "url":"https://t.me/Lanternpro_Iran"
-      },
-      "IR":{
-         "enabled":true,
-         "text":"سلام! اطلاعات بیشتر در مورد لنترن پرو در",
-         "url":"https://t.me/Lanternpro_Iran"
       }
    },
    "desktopBannerAds":{
@@ -730,22 +720,22 @@
    },
    "surveys":{
       "IR":{
-         "enabled":false,
+         "enabled":true,
          "probability":1.00,
          "showPlansScreen": false,
-         "url":"https://www.youtube.com/watch?v=X5DYspZf-2k",
-         "message":"ویدیوی داغ هفته. به خالکوبی و تاتوی مائده هژبری دقت کنید",
-         "thanks":"با تشکر",
-         "button":"تماشا کنید"
+         "url":"https://t.me/Lanternpro_Iran",
+         "message":"سلام! اطلاعات بیشتر در مورد لنترن پرو در",
+         "thanks": "",
+         "button": "مشاهده وبسایت"
       },
       "fa_IR":{
-         "enabled":false,
+         "enabled":true,
          "probability":1.00,
          "showPlansScreen": false,
-         "url":"https://www.youtube.com/watch?v=X5DYspZf-2k",
-         "message":"ویدیوی داغ هفته. به خالکوبی و تاتوی مائده هژبری دقت کنید",
-         "thanks":"با تشکر",
-         "button":"تماشا کنید"
+         "url":"https://t.me/Lanternpro_Iran",
+         "message":"سلام! اطلاعات بیشتر در مورد لنترن پرو در",
+         "thanks": "",
+         "button": "مشاهده وبسایت"
       },
       "AE":{
          "enabled":false,


### PR DESCRIPTION
Because banner ads doesn't show up on desktop if Yinbi is not enabled
(https://github.com/getlantern/lantern-internal/issues/3528). Somehow it
didn't show up on Android as well.