### PR TITLE
Add version matching staging surveys and information in README about version matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ Desktop also support the special "ANY" flag indicating all users reporting any i
   },
 }
 ```
+
+*NOTE:*
+Version and subscription matching have been added to the desktop UI, but because of backwards compatibility concerns, the implementation is a little hacky and so there are some serious 🐍s an 🐉s.
+Version matching only applies to objects whose property already matches the language-location key.
+Additionally, because older clients won't understand version matching, if you create a survey with a version constraint, you must set `enabled` to false so that older clients won't attempt to display it 🙁.
+Also, because the surveys use object property keys to match on and an object can only have a single key, there's not a straightforward way to have a survey for the same language/region group with different version constraints.
+It *is* possible to use a kind of hack as shown in the [desktop-ui-staging.json](./desktop-ui-staging.json) file and have one survey use `en-US` and the other use `-en-US`, but it's obviously hairy and not ideal...
+

--- a/desktop-ui-staging.json
+++ b/desktop-ui-staging.json
@@ -37,14 +37,27 @@
 			"thanks": "",
 			"button": "Go Beta!"
 		},
-		"US": {
+		"en-US": {
 			"enabled": false,
-			"probability": 0.00,
-			"campaign": "US20170405",
-			"url": "?utm_source=upgradesnack&utm_campaign=Privateupgrade#/plans",
-			"message": "Check out the beta group",
+			"probability": 1,
+			"campaign": "RANDOMUSLOCONFTESTINGCAMPAIGN2",
+			"url": "https://lantern.io",
+			"message": "I'm a message for free en-US free users with a version constraint. Because of backwards compatibility with clients that don't understand version constraints, we need to set enabled to false here :/",
 			"thanks": "",
-			"button": "Go Beta!"
+			"button": "OK",
+			"pro": false,
+			"versions": ">1.0.0"
+		},
+		"-en-US": {
+			"enabled": false,
+			"probability": 1,
+			"campaign": "RANDOMUSLOCONFTESTINGCAMPAIGN3",
+			"url": "https://lantern.io",
+			"message": "Here's a weird hack to display a message for en-US pro users with a version constraint",
+			"thanks": "",
+			"button": "OK",
+			"versions": ">1.0.0",
+			"pro": true
 		},
 		"en": {
 			"enabled": false,

--- a/desktop-ui.json
+++ b/desktop-ui.json
@@ -28,6 +28,16 @@
 		}
 	},
 	"survey": {
+		"en-US": {
+			"enabled": false,
+			"probability": 1,
+			"campaign": "REPLICABETAu6j0xkh4TTnh9ZF0qFo",
+			"url": "https://lantern.io",
+			"message": "Hey you're using the early lantern beta - this is just a test that loconf works :)",
+			"thanks": "",
+			"button": "OK",
+			"versions": "6.0.0-beta6"
+		},
 		"en-IR": {
 			"enabled": false,
 			"probability": 0.00,


### PR DESCRIPTION
This is a staging demo of https://github.com/getlantern/lantern-desktop-ui/pull/514

Obviously the whole setup is not exactly ideal...