### PR TITLE
Update replica surveys with new CN link and features matching

### DIFF
--- a/desktop-ui.json
+++ b/desktop-ui.json
@@ -31,22 +31,28 @@
 		"zh-CN": {
 			"enabled": false,
 			"probability": 1,
-			"campaign": "replica-survey-zh-CH-6.0.0-beta6-2020-07-13",
-			"url": "https://www.surveymonkey.com/r/W7B6R5J",
+			"campaign": "replica-survey-zh-CH-6.0.0-2020-08-18",
+			"url": "https://www.surveymonkey.com/r/FCVRJKP",
 			"message": "让我们知道您对Lantern的新功能的想法！",
 			"thanks": "",
 			"button": "参与调查",
-			"versions": "6.0.0-beta6"
+			"versions": ">6.0.0",
+			"features": {
+				"replica": true
+			}
 		},
 		"fa-IR": {
 			"enabled": false,
 			"probability": 1,
-			"campaign": "replica-survey-fa-IR-6.0.0-beta6-2020-07-16",
+			"campaign": "replica-survey-fa-IR-6.0.0-2020-08-18",
 			"url": "https://www.surveymonkey.com/r/3JKFFR8",
 			"message": "لطفا ما را از نظراتتان درباره ی ویژگی های جدید لنترن مطلع کنید.",
 			"thanks": "",
 			"button": "در نظرسنجی شرکت کنید",
-			"versions": "6.0.0-beta6"
+			"versions": ">=6.0.0",
+			"features": {
+				"replica": true
+			}
 		},
 		"US": {
 			"enabled":false,


### PR DESCRIPTION
Sets the survey to show for `CN` and `IR` with any version >= 6.0.0 and replica turned on.